### PR TITLE
Fix for issue #6, problem for test of reading SDHC cards (32GB or larger)

### DIFF
--- a/SdReader.h
+++ b/SdReader.h
@@ -64,6 +64,9 @@
 #define SD_CARD_ERROR_READ_TIMEOUT 0XD
 /** card returned an error token instead of read data */
 #define SD_CARD_ERROR_READ 0X10
+/** unsupported CSD version */
+#define SD_CARD_ERROR_UNSUPPORTED_CSD_VERSION 0x11
+
 //
 // card types
 /** Standard capacity V1 SD card */

--- a/examples/SdReadTest/SdReadTest.ino
+++ b/examples/SdReadTest/SdReadTest.ino
@@ -141,6 +141,10 @@ void loop(void) {
     putstring_nl("\nRead Failure");
     putstring("lbn: ");
     Serial.println(b);  
+    putstring("nRead: ");
+    Serial.print(nRead);
+    putstring("/");
+    Serial.println(nTest);
     sdError();
   }
 }


### PR DESCRIPTION
Adds a missing cast in SdReader.h for the size() method. Added new error value for reading a card with unsupported header.

This is a minor change to SdReader.h and SdReader.cpp that fixes a bug in reading the size
of large SD cards.  I imagine most code that uses the library doesn't depend on this function,
but the SdReadTest unit test does.

See the equivalent code in https://github.com/greiman/SdFat/blob/master/src/SdCard/SdCardInfo.h#L326

I ran all examples in the WaveHC library. I discovered this when vetting my change for fixing issue #3 and decided to break it out into a separate PR.

Before this fix, the card size reported by the test was insanely large, probably caused by the top bit being set in a 16 bit int implicitly used when 'mid' is not cast:

```
card size: 4290192384 (512 byte blocks)
```

After this fix, the SdReader test reports a sane card size:

```
card size: 62333952 (512 byte blocks)

```